### PR TITLE
Allow for embeddings to be saved

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: BLfuzzylink
+Package: BFfuzzylink
 Title: Probabilistic Record Linkage Using Pretrained Text Embeddings
 Version: 0.2.5
 Authors@R: 

--- a/R/fuzzylink.R
+++ b/R/fuzzylink.R
@@ -17,6 +17,7 @@
 #' @param return_all_pairs If TRUE, returns *every* within-block record pair from dfA and dfB, not just validated pairs. Defaults to FALSE.
 #' @param embedding_port_num The port number that the local embedding model is running on. Defaults to 8080. 
 #' @param text_gen_port_num The port number that the local text generation model is running on. Defaults to 8081. 
+#' @param save_embeddings TRUE to save the embeddings to <embedding_model>_embeddings.RData. Defaults to FALSE.
 #' @param debug TRUE to print various statments throughout the code to track progess. Defaults to FALSE.
 #'
 #' @return A dataframe with all rows of `dfA` joined with any matches from `dfB`
@@ -48,16 +49,13 @@ fuzzylink <- function(dfA, dfB,
                       return_all_pairs = FALSE,
                       embedding_port_num = 8080,
                       text_gen_port_num = 8081,
-                      # name = NULL, #The 'name' of this run for saving intermediate files. Defaults to the name of the model + embedding_model
+                      save_embeddings = FALSE,
                       debug = FALSE){
 
   # Check for errors in inputs
   if(debug){
     print("DEBUG: Beginning to check for errors in inputs")
   }
-  # if(is.null(name)) {
-  #   name <- paste(model, embedding_model, sep='_')
-  # }
 
   if(is.null(dfA[[by]])){
     stop("There is no variable called \'", by, "\' in dfA.")
@@ -131,7 +129,11 @@ fuzzylink <- function(dfA, dfB,
                                port_number = embedding_port_num,
                                debug = debug)
 
-  
+  if(save_embeddings) {
+    current_directory <- getwd()
+    embedding_filename <- paste(embedding_model,"embeddings.RData", sep='_')
+    save(embeddings, file = paste0(current_directory, "/", embedding_filename))
+  }
 
   ## Step 2: Get similarity matrix within each block ------------
   if(debug){


### PR DESCRIPTION
The main `fuzzylink` function now supports a parameter, `save_embeddings`, which, when set to true, saves the embeddings to a .RData file in the user's working directory.

In the future, the `fuzzylink` function could also be further broken down into more isolated functions. The `fuzzylink` function would still work, but users could also have access to more functions which would allow them to run the steps of the fuzzylink algorithm sequentially. For example, a user could simply get and save the embeddings, and then later call various functions to complete the rest of the fuzzylink procedure using their saved embeddings. 